### PR TITLE
FIX: #1075 Image multiplier loop in ImageVariantsUtility.php

### DIFF
--- a/Classes/Utility/ImageVariantsUtility.php
+++ b/Classes/Utility/ImageVariantsUtility.php
@@ -191,9 +191,9 @@ class ImageVariantsUtility
      */
     protected static function processMultiplier(array $variants, array $multiplier): array
     {
-        foreach ($multiplier as $variant => $value) {
-            if (is_numeric($value) && $value > 0 && isset($variants[$variant]['width'])) {
-                $variants[$variant]['width'] = (int) ceil($variants[$variant]['width'] * (float) $value);
+        foreach ($variants as $key => $variant) {
+            if (isset($variant['width'])) {
+                $variants[$key]['width'] = (int) ceil($variant['width'] * (float) ($multiplier[$key] ?? $multiplier['default'] ?? 1));
             }
         }
         return $variants;


### PR DESCRIPTION
Loop over variants and apply the right multiplier instead of looping over variants.

# Pull Request

## Related Issues

* Closes #
* Fixes # [bug]
* Resolves # [feature/question]

## Prerequisites

* [ ] Changes have been tested on TYPO3 v9.5 LTS
* [ ] Changes have been tested on TYPO3 v10.4 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.2.x
* [ ] Changes have been tested on PHP 7.3.x
* [ ] Changes have been tested on PHP 7.4.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

[Description of changes proposed in this pull request]

## Steps to Validate

1. [First Step]
2. [Second Step]
3. [and so on...]
